### PR TITLE
Add hooks to hide and reorder admin menus and submenus

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
-# WMA-ADMIN-MENU
+# WMA Admin Menu
+
+Provides utility hooks to hide or rearrange menu and submenu items in the WordPress admin area.
+
+## Usage
+
+```php
+// Hide top-level menus.
+add_filter( 'wma_admin_hidden_menus', function( $menus ) {
+    $menus[] = 'edit.php'; // Hide Posts menu.
+    return $menus;
+} );
+
+// Reorder top-level menus.
+add_filter( 'wma_admin_menu_order', function( $order ) {
+    $order[] = 'options-general.php'; // Settings first.
+    $order[] = 'index.php';          // Dashboard second.
+    return $order;
+} );
+
+// Hide submenus.
+add_filter( 'wma_admin_hidden_submenus', function( $items ) {
+    $items[] = [
+        'parent'  => 'options-general.php',  // Parent menu slug.
+        'submenu' => 'options-writing.php', // Submenu slug to hide.
+    ];
+    return $items;
+} );
+
+// Reorder submenus.
+add_filter( 'wma_admin_submenu_order', function( $order ) {
+    $order['options-general.php'] = [
+        'options-reading.php',
+        'options-general.php',
+    ];
+    return $order;
+} );
+```

--- a/tests/plugin_test.php
+++ b/tests/plugin_test.php
@@ -1,0 +1,105 @@
+<?php
+// Minimal WordPress hook stubs for testing.
+
+define('ABSPATH', __DIR__);
+
+$filters = [];
+$actions = [];
+
+function add_filter($tag, $callback, $priority = 10) {
+    global $filters;
+    $filters[$tag][$priority][] = $callback;
+}
+
+function apply_filters($tag, $value) {
+    global $filters;
+    if (empty($filters[$tag])) {
+        return $value;
+    }
+    ksort($filters[$tag]);
+    foreach ($filters[$tag] as $priority => $callbacks) {
+        foreach ($callbacks as $cb) {
+            $value = call_user_func($cb, $value);
+        }
+    }
+    return $value;
+}
+
+function add_action($tag, $callback, $priority = 10) {
+    global $actions;
+    $actions[$tag][$priority][] = $callback;
+}
+
+function do_action($tag, ...$args) {
+    global $actions;
+    if (empty($actions[$tag])) {
+        return;
+    }
+    ksort($actions[$tag]);
+    foreach ($actions[$tag] as $priority => $callbacks) {
+        foreach ($callbacks as $cb) {
+            call_user_func_array($cb, $args);
+        }
+    }
+}
+
+require_once __DIR__ . '/../wma-admin-menu.php';
+
+global $menu, $submenu;
+$menu = [
+    ['Dashboard', 'read', 'index.php'],
+    ['Posts', 'edit_posts', 'edit.php'],
+    ['Settings', 'manage_options', 'options-general.php'],
+];
+$submenu = [
+    'options-general.php' => [
+        ['General', 'manage_options', 'options-general.php'],
+        ['Writing', 'manage_options', 'options-writing.php'],
+        ['Reading', 'manage_options', 'options-reading.php'],
+    ],
+    'edit.php' => [
+        ['All Posts', 'edit_posts', 'edit.php'],
+        ['Add New', 'edit_posts', 'post-new.php'],
+    ],
+];
+
+add_filter('wma_admin_hidden_menus', function($menus) {
+    $menus[] = 'edit.php';
+    return $menus;
+});
+
+add_filter('wma_admin_menu_order', function($order) {
+    $order[] = 'options-general.php';
+    $order[] = 'index.php';
+    return $order;
+});
+
+add_filter('wma_admin_hidden_submenus', function($items) {
+    $items[] = ['parent' => 'options-general.php', 'submenu' => 'options-writing.php'];
+    return $items;
+});
+
+add_filter('wma_admin_submenu_order', function($order) {
+    $order['options-general.php'] = ['options-reading.php', 'options-general.php'];
+    return $order;
+});
+
+do_action('admin_menu');
+
+$expected_menu = [
+    ['Settings', 'manage_options', 'options-general.php'],
+    ['Dashboard', 'read', 'index.php'],
+];
+$expected_submenu_settings = [
+    ['Reading', 'manage_options', 'options-reading.php'],
+    ['General', 'manage_options', 'options-general.php'],
+];
+
+if ($menu === $expected_menu && $submenu['options-general.php'] === $expected_submenu_settings) {
+    echo "All tests passed\n";
+    exit(0);
+}
+
+echo "Tests failed\n";
+var_export(['menu' => $menu, 'submenu' => $submenu]);
+exit(1);

--- a/wma-admin-menu.php
+++ b/wma-admin-menu.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * Plugin Name: WMA Admin Menu
+ * Description: Provides functions to hide and rearrange admin menu and submenu items.
+ * Version: 1.0.0
+ * Author: OpenAI Assistant
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+/**
+ * Class WMA_Admin_Menu
+ *
+ * Offers filters to hide and reorder submenu items within the WordPress admin area.
+ */
+class WMA_Admin_Menu {
+
+    public function __construct() {
+        add_action( 'admin_menu', [ $this, 'modify_menus' ], 999 );
+    }
+
+    /**
+     * Hide or reorder menu and submenu items based on filters.
+     */
+    public function modify_menus() {
+        global $menu, $submenu;
+
+        $this->hide_menus( $menu );
+        $this->reorder_menus( $menu );
+
+        $this->hide_submenus( $submenu );
+        $this->reorder_submenus( $submenu );
+    }
+
+    /**
+     * Removes top-level menu items using the `wma_admin_hidden_menus` filter.
+     *
+     * @param array $menu Global menu array passed by reference.
+     */
+    private function hide_menus( array &$menu ) {
+        $to_hide = apply_filters( 'wma_admin_hidden_menus', [] );
+
+        if ( empty( $to_hide ) ) {
+            return;
+        }
+
+        foreach ( $menu as $index => $data ) {
+            if ( isset( $data[2] ) && in_array( $data[2], $to_hide, true ) ) {
+                unset( $menu[ $index ] );
+            }
+        }
+    }
+
+    /**
+     * Reorders top-level menu items using the `wma_admin_menu_order` filter.
+     *
+     * @param array $menu Global menu array passed by reference.
+     */
+    private function reorder_menus( array &$menu ) {
+        $desired_order = apply_filters( 'wma_admin_menu_order', [] );
+
+        if ( empty( $desired_order ) ) {
+            return;
+        }
+
+        $current = $menu;
+        $sorted  = [];
+
+        foreach ( $desired_order as $slug ) {
+            foreach ( $current as $index => $data ) {
+                if ( isset( $data[2] ) && $data[2] === $slug ) {
+                    $sorted[] = $data;
+                    unset( $current[ $index ] );
+                }
+            }
+        }
+
+        // Append remaining items that were not explicitly ordered.
+        $menu = array_merge( $sorted, $current );
+    }
+
+    /**
+     * Removes submenu items using the `wma_admin_hidden_submenus` filter.
+     *
+     * @param array $submenu Global submenu array passed by reference.
+     */
+    private function hide_submenus( array &$submenu ) {
+        $to_hide = apply_filters( 'wma_admin_hidden_submenus', [] );
+
+        foreach ( $to_hide as $item ) {
+            if ( empty( $item['parent'] ) || empty( $item['submenu'] ) ) {
+                continue;
+            }
+
+            $parent  = $item['parent'];
+            $submenu_slug = $item['submenu'];
+
+            if ( ! isset( $submenu[ $parent ] ) ) {
+                continue;
+            }
+
+            foreach ( $submenu[ $parent ] as $index => $data ) {
+                if ( isset( $data[2] ) && $data[2] === $submenu_slug ) {
+                    unset( $submenu[ $parent ][ $index ] );
+                }
+            }
+        }
+    }
+
+    /**
+     * Reorders submenu items using the `wma_admin_submenu_order` filter.
+     *
+     * Filter format:
+     *     [
+     *         'parent-slug' => [ 'submenu-slug-1', 'submenu-slug-2' ]
+     *     ]
+     * Any submenu slugs omitted from the array maintain their relative order
+     * after the specified items.
+     *
+     * @param array $submenu Global submenu array passed by reference.
+     */
+    private function reorder_submenus( array &$submenu ) {
+        $order_map = apply_filters( 'wma_admin_submenu_order', [] );
+
+        foreach ( $order_map as $parent => $desired_order ) {
+            if ( ! isset( $submenu[ $parent ] ) || ! is_array( $desired_order ) ) {
+                continue;
+            }
+
+            $current      = $submenu[ $parent ];
+            $sorted_items = [];
+
+            foreach ( $desired_order as $slug ) {
+                foreach ( $current as $index => $data ) {
+                    if ( isset( $data[2] ) && $data[2] === $slug ) {
+                        $sorted_items[] = $data;
+                        unset( $current[ $index ] );
+                    }
+                }
+            }
+
+            // Append remaining items that were not explicitly ordered.
+            $submenu[ $parent ] = array_merge( $sorted_items, $current );
+        }
+    }
+}
+
+new WMA_Admin_Menu();


### PR DESCRIPTION
## Summary
- support hiding and reordering top-level admin menus
- extend submenu tools and add test verifying menu behavior
- document usage examples for menu and submenu filters

## Testing
- `php -l wma-admin-menu.php`
- `php tests/plugin_test.php`


------
https://chatgpt.com/codex/tasks/task_e_68bad56d670c833086070b8bca6fc9a4