### PR TITLE
Ensure settings page registers before menu modifications

### DIFF
--- a/wma-admin-menu.php
+++ b/wma-admin-menu.php
@@ -26,7 +26,7 @@ class WMA_Admin_Menu {
 
     public function __construct() {
         add_action( 'admin_init', [ $this, 'register_settings' ] );
-        add_action( 'admin_menu', [ $this, 'add_settings_page' ] );
+        add_action( 'admin_menu', [ $this, 'add_settings_page' ], 998 );
         add_action( 'admin_menu', [ $this, 'modify_menus' ], 999 );
     }
 


### PR DESCRIPTION
## Summary
- ensure the settings page registers on `admin_menu` with a priority lower than `modify_menus`

## Testing
- php -l wma-admin-menu.php

------
https://chatgpt.com/codex/tasks/task_e_68d0115642448330a1fed781c920394d