### PR TITLE
Add collapsible submenu controls to settings UI

### DIFF
--- a/assets/admin-menu.css
+++ b/assets/admin-menu.css
@@ -1,0 +1,126 @@
+.wma-admin-menu__checkbox-group {
+    border: 1px solid #dcdcde;
+    border-radius: 10px;
+    padding: 1rem 1.25rem;
+    background: #ffffff;
+    display: grid;
+    gap: 0.6rem;
+    max-width: 36rem;
+    box-shadow: 0 1px 2px rgba(30, 35, 40, 0.05);
+}
+
+.wma-admin-menu__menu-item,
+.wma-admin-menu__submenu-item {
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
+    font-size: 13px;
+    color: #2c3338;
+}
+
+.wma-admin-menu__menu-item span,
+.wma-admin-menu__submenu-item span {
+    flex: 1;
+}
+
+.wma-admin-menu__checkbox-group input[type="checkbox"],
+.wma-admin-menu__submenu-item input[type="checkbox"] {
+    margin: 0;
+    accent-color: #2271b1;
+}
+
+.wma-admin-menu__submenu-group {
+    display: grid;
+    gap: 1rem;
+    margin-top: 1rem;
+}
+
+.wma-admin-menu__submenu-row {
+    border: 1px solid #dcdcde;
+    border-radius: 12px;
+    background: #ffffff;
+    box-shadow: 0 1px 3px rgba(30, 35, 40, 0.12);
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+    overflow: hidden;
+}
+
+.wma-admin-menu__submenu-row.is-open {
+    border-color: #2271b1;
+    box-shadow: 0 12px 24px -18px rgba(34, 113, 177, 0.8);
+}
+
+.wma-admin-menu__submenu-toggle {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.95rem 1.2rem;
+    background: transparent;
+    border: 0;
+    cursor: pointer;
+    font-size: 14px;
+    font-weight: 600;
+    color: #1d2327;
+    text-align: left;
+    transition: color 0.2s ease, background-color 0.2s ease;
+}
+
+.wma-admin-menu__submenu-row.is-open .wma-admin-menu__submenu-toggle {
+    color: #0a4b78;
+    background: linear-gradient(180deg, #f4f9ff 0%, #edf4ff 100%);
+}
+
+.wma-admin-menu__submenu-toggle:focus-visible {
+    outline: 2px solid #72aee6;
+    outline-offset: 2px;
+}
+
+.wma-admin-menu__submenu-icon {
+    position: relative;
+    width: 0.9rem;
+    height: 0.9rem;
+    flex-shrink: 0;
+    color: currentColor;
+}
+
+.wma-admin-menu__submenu-icon::before {
+    content: '';
+    position: absolute;
+    width: 0.55rem;
+    height: 0.55rem;
+    border-top: 2px solid currentColor;
+    border-right: 2px solid currentColor;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%) rotate(45deg);
+    transition: transform 0.2s ease;
+}
+
+.wma-admin-menu__submenu-row.is-open .wma-admin-menu__submenu-icon::before {
+    transform: translate(-50%, -50%) rotate(135deg);
+}
+
+.wma-admin-menu__submenu-items {
+    padding: 0.1rem 1.2rem 1.2rem;
+    display: grid;
+    gap: 0.45rem;
+    background: #f6f7f7;
+}
+
+.wma-admin-menu__submenu-items[aria-hidden="true"] {
+    display: none;
+}
+
+.wma-admin-menu__submenu-item {
+    background: #ffffff;
+    border-radius: 6px;
+    padding: 0.4rem 0.6rem;
+    box-shadow: inset 0 0 0 1px #e0e4e7;
+    transition: box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.wma-admin-menu__submenu-item:hover {
+    box-shadow: inset 0 0 0 1px #b3d4f5;
+    background: #f7fbff;
+}

--- a/assets/admin-menu.js
+++ b/assets/admin-menu.js
@@ -1,0 +1,115 @@
+(function() {
+    'use strict';
+
+    var matches = function(element, selector) {
+        if (!element || element.nodeType !== 1) {
+            return false;
+        }
+
+        var proto = element.matches || element.matchesSelector || element.msMatchesSelector || element.webkitMatchesSelector || element.mozMatchesSelector;
+
+        if (proto) {
+            return proto.call(element, selector);
+        }
+
+        var doc = element.ownerDocument || document;
+        var nodes = doc.querySelectorAll(selector);
+        var index = 0;
+
+        while (nodes[index]) {
+            if (nodes[index] === element) {
+                return true;
+            }
+            index += 1;
+        }
+
+        return false;
+    };
+
+    var findClosest = function(element, selector) {
+        if (!element || element.nodeType !== 1) {
+            return null;
+        }
+
+        if (element.closest) {
+            return element.closest(selector);
+        }
+
+        var node = element;
+
+        while (node && node.nodeType === 1) {
+            if (matches(node, selector)) {
+                return node;
+            }
+            node = node.parentElement;
+        }
+
+        return null;
+    };
+
+    var initializeToggleRows = function() {
+        var rows = document.querySelectorAll('.wma-admin-menu__submenu-row');
+
+        if (!rows.length) {
+            return;
+        }
+
+        var setOpenState = function(row, toggle, container, isOpen) {
+            toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+            container.setAttribute('aria-hidden', isOpen ? 'false' : 'true');
+
+            if (isOpen) {
+                row.classList.add('is-open');
+            } else {
+                row.classList.remove('is-open');
+            }
+        };
+
+        Array.prototype.forEach.call(rows, function(row) {
+            var toggle = row.querySelector('.wma-admin-menu__submenu-toggle');
+            var container = row.querySelector('.wma-admin-menu__submenu-items');
+
+            if (!toggle || !container) {
+                return;
+            }
+
+            var isInitiallyExpanded = toggle.getAttribute('aria-expanded') === 'true';
+            setOpenState(row, toggle, container, isInitiallyExpanded);
+
+            var toggleState = function(event) {
+                if (event) {
+                    event.stopPropagation();
+
+                    if ('click' === event.type) {
+                        event.preventDefault();
+                    }
+                }
+
+                var isOpen = toggle.getAttribute('aria-expanded') === 'true';
+                setOpenState(row, toggle, container, !isOpen);
+            };
+
+            toggle.addEventListener('click', toggleState);
+
+            row.addEventListener('click', function(event) {
+                var target = event.target;
+
+                if (findClosest(target, '.wma-admin-menu__submenu-toggle')) {
+                    return;
+                }
+
+                if (findClosest(target, '.wma-admin-menu__submenu-items')) {
+                    return;
+                }
+
+                toggleState(event);
+            });
+        });
+    };
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initializeToggleRows);
+    } else {
+        initializeToggleRows();
+    }
+})();


### PR DESCRIPTION
## Summary
- refactor the submenu checklist markup so each parent row wraps its hidden item checkboxes
- add lightweight JavaScript and CSS assets for the collapsible UI and enqueue them on the plugin settings page
- expose a plugin version constant and asset version helper for cache-busting when loading the assets

## Testing
- php tests/plugin_test.php

------
https://chatgpt.com/codex/tasks/task_e_68d0ad29c38883308c51f4370e805ebb