### PR TITLE
Add label override controls for admin menus

### DIFF
--- a/assets/admin-menu.css
+++ b/assets/admin-menu.css
@@ -1,43 +1,110 @@
-.wma-admin-menu__checkbox-group {
+.wma-admin-menu__sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    border: 0;
+}
+
+.wma-admin-menu__field-label {
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: #6c7781;
+}
+
+.wma-admin-menu__text-input {
+    width: 100%;
     border: 1px solid #dcdcde;
-    border-radius: 10px;
-    padding: 1rem 1.25rem;
+    border-radius: 6px;
+    padding: 0.45rem 0.6rem;
+    font-size: 13px;
+    line-height: 1.4;
+    color: #1d2327;
+    background: #ffffff;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.wma-admin-menu__text-input:focus {
+    border-color: #2271b1;
+    box-shadow: 0 0 0 1px #2271b1;
+    outline: none;
+    background: #f7fbff;
+}
+
+.wma-admin-menu__menu-group {
+    border: 1px solid #dcdcde;
+    border-radius: 14px;
+    padding: 1.25rem;
     background: #ffffff;
     display: grid;
-    gap: 0.6rem;
-    max-width: 36rem;
-    box-shadow: 0 1px 2px rgba(30, 35, 40, 0.05);
+    gap: 0.85rem;
+    max-width: 60rem;
+    box-shadow: 0 1px 2px rgba(30, 35, 40, 0.08);
 }
 
-.wma-admin-menu__menu-item,
-.wma-admin-menu__submenu-item {
+.wma-admin-menu__menu-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1.4fr) minmax(12rem, 1fr);
+    gap: 1.25rem;
+    align-items: center;
+    padding: 0.85rem 1.05rem;
+    border-radius: 10px;
+    border: 1px solid #edf0f3;
+    background: #f9fafb;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.wma-admin-menu__menu-row:hover {
+    border-color: #c8d7eb;
+    box-shadow: 0 8px 20px -18px rgba(34, 113, 177, 0.8);
+}
+
+.wma-admin-menu__menu-row.has-custom-label {
+    border-color: #2271b1;
+    background: #f3f8ff;
+    box-shadow: 0 12px 28px -20px rgba(34, 113, 177, 0.85);
+}
+
+.wma-admin-menu__menu-primary {
     display: flex;
     align-items: center;
-    gap: 0.55rem;
-    font-size: 13px;
-    color: #2c3338;
+    gap: 0.65rem;
 }
 
-.wma-admin-menu__menu-item span,
-.wma-admin-menu__submenu-item span {
-    flex: 1;
-}
-
-.wma-admin-menu__checkbox-group input[type="checkbox"],
-.wma-admin-menu__submenu-item input[type="checkbox"] {
+.wma-admin-menu__menu-primary input[type="checkbox"] {
     margin: 0;
     accent-color: #2271b1;
+    width: 16px;
+    height: 16px;
+    flex-shrink: 0;
+}
+
+.wma-admin-menu__menu-name {
+    font-size: 14px;
+    font-weight: 600;
+    color: #1d2327;
+}
+
+.wma-admin-menu__menu-rename {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
 }
 
 .wma-admin-menu__submenu-group {
     display: grid;
-    gap: 1rem;
-    margin-top: 1rem;
+    gap: 1.4rem;
+    margin-top: 1.8rem;
 }
 
 .wma-admin-menu__submenu-row {
     border: 1px solid #dcdcde;
-    border-radius: 12px;
+    border-radius: 16px;
     background: #ffffff;
     box-shadow: 0 1px 3px rgba(30, 35, 40, 0.12);
     transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
@@ -46,7 +113,21 @@
 
 .wma-admin-menu__submenu-row.is-open {
     border-color: #2271b1;
-    box-shadow: 0 12px 24px -18px rgba(34, 113, 177, 0.8);
+    box-shadow: 0 22px 32px -24px rgba(34, 113, 177, 0.9);
+}
+
+.wma-admin-menu__submenu-header {
+    display: grid;
+    grid-template-columns: minmax(0, 1.4fr) minmax(14rem, 1fr);
+    gap: 1.2rem;
+    align-items: center;
+    padding: 1.05rem 1.3rem;
+    background: linear-gradient(180deg, #f9fafb 0%, #f2f3f5 100%);
+    border-bottom: 1px solid #e6e9ed;
+}
+
+.wma-admin-menu__submenu-row.is-open .wma-admin-menu__submenu-header {
+    background: linear-gradient(180deg, #f4f9ff 0%, #eaf3ff 100%);
 }
 
 .wma-admin-menu__submenu-toggle {
@@ -54,32 +135,35 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: 0.75rem;
-    padding: 0.95rem 1.2rem;
+    gap: 0.85rem;
+    padding: 0;
     background: transparent;
     border: 0;
     cursor: pointer;
-    font-size: 14px;
+    font-size: 15px;
     font-weight: 600;
     color: #1d2327;
     text-align: left;
-    transition: color 0.2s ease, background-color 0.2s ease;
 }
 
 .wma-admin-menu__submenu-row.is-open .wma-admin-menu__submenu-toggle {
     color: #0a4b78;
-    background: linear-gradient(180deg, #f4f9ff 0%, #edf4ff 100%);
 }
 
 .wma-admin-menu__submenu-toggle:focus-visible {
     outline: 2px solid #72aee6;
-    outline-offset: 2px;
+    outline-offset: 3px;
+}
+
+.wma-admin-menu__submenu-title {
+    flex: 1;
+    line-height: 1.4;
 }
 
 .wma-admin-menu__submenu-icon {
     position: relative;
-    width: 0.9rem;
-    height: 0.9rem;
+    width: 1rem;
+    height: 1rem;
     flex-shrink: 0;
     color: currentColor;
 }
@@ -87,8 +171,8 @@
 .wma-admin-menu__submenu-icon::before {
     content: '';
     position: absolute;
-    width: 0.55rem;
-    height: 0.55rem;
+    width: 0.6rem;
+    height: 0.6rem;
     border-top: 2px solid currentColor;
     border-right: 2px solid currentColor;
     top: 50%;
@@ -101,10 +185,16 @@
     transform: translate(-50%, -50%) rotate(135deg);
 }
 
+.wma-admin-menu__submenu-parent-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
 .wma-admin-menu__submenu-items {
-    padding: 0.1rem 1.2rem 1.2rem;
+    padding: 1.1rem 1.3rem 1.3rem;
     display: grid;
-    gap: 0.45rem;
+    gap: 0.75rem;
     background: #f6f7f7;
 }
 
@@ -113,14 +203,70 @@
 }
 
 .wma-admin-menu__submenu-item {
+    display: grid;
+    grid-template-columns: minmax(0, 1.4fr) minmax(12rem, 1fr);
+    gap: 1rem;
+    align-items: center;
+    padding: 0.7rem 0.9rem;
+    border-radius: 10px;
+    border: 1px solid #e3e7ec;
     background: #ffffff;
-    border-radius: 6px;
-    padding: 0.4rem 0.6rem;
-    box-shadow: inset 0 0 0 1px #e0e4e7;
-    transition: box-shadow 0.2s ease, background-color 0.2s ease;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
 }
 
 .wma-admin-menu__submenu-item:hover {
-    box-shadow: inset 0 0 0 1px #b3d4f5;
-    background: #f7fbff;
+    border-color: #c8d7eb;
+    box-shadow: 0 10px 24px -22px rgba(34, 113, 177, 0.8);
+}
+
+.wma-admin-menu__submenu-item.has-custom-label {
+    border-color: #2271b1;
+    background: #f3f8ff;
+    box-shadow: 0 16px 30px -22px rgba(34, 113, 177, 0.88);
+}
+
+.wma-admin-menu__submenu-item-primary {
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
+}
+
+.wma-admin-menu__submenu-item-primary input[type="checkbox"] {
+    margin: 0;
+    accent-color: #2271b1;
+    width: 16px;
+    height: 16px;
+    flex-shrink: 0;
+}
+
+.wma-admin-menu__submenu-name {
+    font-size: 13px;
+    font-weight: 500;
+    color: #2c3338;
+}
+
+.wma-admin-menu__submenu-item-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+@media (max-width: 960px) {
+    .wma-admin-menu__menu-row,
+    .wma-admin-menu__submenu-header,
+    .wma-admin-menu__submenu-item {
+        grid-template-columns: 1fr;
+    }
+
+    .wma-admin-menu__submenu-header {
+        gap: 0.75rem;
+    }
+
+    .wma-admin-menu__menu-group {
+        padding: 1rem;
+    }
+
+    .wma-admin-menu__submenu-items {
+        padding: 1rem 1rem 1.2rem;
+    }
 }

--- a/assets/admin-menu.js
+++ b/assets/admin-menu.js
@@ -47,6 +47,127 @@
         return null;
     };
 
+    var getTrimmedValue = function(input) {
+        if (!input || typeof input.value !== 'string') {
+            return '';
+        }
+
+        return input.value.replace(/\s+/g, ' ').trim();
+    };
+
+    var updateRowHighlight = function(row) {
+        if (!row) {
+            return;
+        }
+
+        var inputs = row.querySelectorAll('.wma-admin-menu__text-input');
+        var hasValue = false;
+
+        Array.prototype.forEach.call(inputs, function(input) {
+            if (getTrimmedValue(input)) {
+                hasValue = true;
+            }
+        });
+
+        if (hasValue) {
+            row.classList.add('has-custom-label');
+        } else {
+            row.classList.remove('has-custom-label');
+        }
+    };
+
+    var updateInputHighlight = function(input) {
+        if (!input) {
+            return;
+        }
+
+        var value = getTrimmedValue(input);
+        var row = findClosest(input, '.wma-admin-menu__submenu-row');
+        var host = findClosest(input, '.wma-admin-menu__submenu-item');
+
+        if (host) {
+            if (value) {
+                host.classList.add('has-custom-label');
+            } else {
+                host.classList.remove('has-custom-label');
+            }
+
+            if (row) {
+                updateRowHighlight(row);
+            }
+
+            return;
+        }
+
+        host = findClosest(input, '.wma-admin-menu__menu-row');
+
+        if (host) {
+            if (value) {
+                host.classList.add('has-custom-label');
+            } else {
+                host.classList.remove('has-custom-label');
+            }
+
+            return;
+        }
+
+        if (row) {
+            if (value) {
+                row.classList.add('has-custom-label');
+            } else {
+                row.classList.remove('has-custom-label');
+            }
+
+            updateRowHighlight(row);
+        }
+    };
+
+    var openRowForInput = function(input) {
+        var row = findClosest(input, '.wma-admin-menu__submenu-row');
+
+        if (!row) {
+            return;
+        }
+
+        var toggle = row.querySelector('.wma-admin-menu__submenu-toggle');
+        var container = row.querySelector('.wma-admin-menu__submenu-items');
+
+        if (!toggle || !container) {
+            return;
+        }
+
+        if (toggle.getAttribute('aria-expanded') === 'true') {
+            return;
+        }
+
+        toggle.setAttribute('aria-expanded', 'true');
+        container.setAttribute('aria-hidden', 'false');
+        row.classList.add('is-open');
+    };
+
+    var bindInputListeners = function(input, openCallback) {
+        if (!input) {
+            return;
+        }
+
+        var handleValueChange = function() {
+            updateInputHighlight(input);
+        };
+
+        input.addEventListener('input', handleValueChange);
+        input.addEventListener('change', handleValueChange);
+
+        input.addEventListener('focus', function() {
+            if (openCallback) {
+                openCallback();
+            } else {
+                openRowForInput(input);
+            }
+        });
+
+        handleValueChange();
+    };
+
     var initializeToggleRows = function() {
         var rows = document.querySelectorAll('.wma-admin-menu__submenu-row');
 
@@ -102,14 +223,54 @@
                     return;
                 }
 
+                if (findClosest(target, '.wma-admin-menu__submenu-parent-field')) {
+                    return;
+                }
+
+                if (findClosest(target, '.wma-admin-menu__submenu-item-field')) {
+                    return;
+                }
+
+                if (findClosest(target, '.wma-admin-menu__text-input')) {
+                    return;
+                }
+
                 toggleState(event);
             });
+
+            var textInputs = row.querySelectorAll('.wma-admin-menu__text-input');
+
+            Array.prototype.forEach.call(textInputs, function(input) {
+                bindInputListeners(input, function() {
+                    setOpenState(row, toggle, container, true);
+                    updateRowHighlight(row);
+                });
+            });
+
+            updateRowHighlight(row);
         });
     };
 
-    if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', initializeToggleRows);
-    } else {
+    var initializeMenuInputs = function() {
+        var inputs = document.querySelectorAll('.wma-admin-menu__menu-row .wma-admin-menu__text-input');
+
+        if (!inputs.length) {
+            return;
+        }
+
+        Array.prototype.forEach.call(inputs, function(input) {
+            bindInputListeners(input);
+        });
+    };
+
+    var init = function() {
         initializeToggleRows();
+        initializeMenuInputs();
+    };
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
     }
 })();


### PR DESCRIPTION
## Summary
- add sanitized menu and submenu label override options along with inputs on the settings screen
- refresh admin styles and scripts to support the new rename controls and improved interactions
- extend automated tests to cover menu and submenu renaming behavior

## Testing
- php tests/plugin_test.php

------
https://chatgpt.com/codex/tasks/task_e_68d0ffc26dd48330b4fa2ca30a69a2dd