### PR TITLE
Add reset workflow to WMA Admin Menu settings screen

### DIFF
--- a/assets/admin-menu.css
+++ b/assets/admin-menu.css
@@ -124,3 +124,39 @@
     box-shadow: inset 0 0 0 1px #b3d4f5;
     background: #f7fbff;
 }
+
+.wma-admin-menu__actions {
+    margin-top: 1.5rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    align-items: center;
+}
+
+.wma-admin-menu__actions .button {
+    min-width: auto;
+}
+
+.wma-admin-menu__reset-button {
+    border-color: #dcdcde;
+    color: #1d2327;
+    background-color: #f6f7f7;
+    transition: color 0.2s ease, background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.wma-admin-menu__reset-button:hover,
+.wma-admin-menu__reset-button:focus {
+    color: #0a4b78;
+    background-color: #e5f1fb;
+    border-color: #72aee6;
+}
+
+.wma-admin-menu__back-link {
+    text-decoration: none;
+}
+
+.wma-admin-menu__reset-description {
+    margin-top: 0.4rem;
+    max-width: 40rem;
+    color: #50575e;
+}

--- a/assets/admin-menu.js
+++ b/assets/admin-menu.js
@@ -107,9 +107,79 @@
         });
     };
 
-    if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', initializeToggleRows);
-    } else {
+    var dispatchEventSafe = function(element, type) {
+        if (!element || 'function' !== typeof element.dispatchEvent) {
+            return;
+        }
+
+        var event;
+
+        if ('function' === typeof window.Event) {
+            event = new Event(type, { bubbles: true });
+        } else {
+            event = document.createEvent('Event');
+            event.initEvent(type, true, true);
+        }
+
+        element.dispatchEvent(event);
+    };
+
+    var applyResetDefaults = function(form) {
+        var renameFields = form.querySelectorAll('[data-wma-rename-default]');
+
+        Array.prototype.forEach.call(renameFields, function(field) {
+            var defaultValue = field.getAttribute('data-wma-rename-default');
+
+            if (typeof defaultValue === 'string') {
+                field.value = defaultValue;
+                dispatchEventSafe(field, 'input');
+                dispatchEventSafe(field, 'change');
+            }
+        });
+
+        var checkboxes = form.querySelectorAll('input[type="checkbox"]');
+
+        Array.prototype.forEach.call(checkboxes, function(checkbox) {
+            checkbox.checked = false;
+        });
+    };
+
+    var initializeResetButton = function() {
+        var form = document.querySelector('[data-wma-settings-form="true"]');
+
+        if (!form) {
+            return;
+        }
+
+        var resetButton = form.querySelector('[data-wma-reset-button="true"]');
+
+        if (!resetButton) {
+            return;
+        }
+
+        resetButton.addEventListener('click', function(event) {
+            var confirmMessage = resetButton.getAttribute('data-wma-reset-confirm');
+
+            if (confirmMessage && !window.confirm(confirmMessage)) {
+                event.preventDefault();
+                event.stopPropagation();
+                return false;
+            }
+
+            applyResetDefaults(form);
+
+            return true;
+        });
+    };
+
+    var initializeAdminMenuSettings = function() {
         initializeToggleRows();
+        initializeResetButton();
+    };
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initializeAdminMenuSettings);
+    } else {
+        initializeAdminMenuSettings();
     }
 })();

--- a/tests/plugin_test.php
+++ b/tests/plugin_test.php
@@ -9,6 +9,30 @@ $options = [
     'wma_admin_hidden_menus'    => [],
     'wma_admin_hidden_submenus' => [],
 ];
+$settings_errors_store = [];
+
+function current_user_can($capability) {
+    return true;
+}
+
+function check_admin_referer($action, $query_arg = '_wpnonce') {
+    return true;
+}
+
+function add_settings_error($setting, $code, $message, $type = 'error') {
+    global $settings_errors_store;
+    $settings_errors_store[] = [
+        'setting' => $setting,
+        'code'    => $code,
+        'message' => $message,
+        'type'    => $type,
+    ];
+}
+
+function settings_errors($setting = '', $sanitize = false, $hide_on_update = false) {
+    global $settings_errors_store;
+    return $settings_errors_store;
+}
 
 function add_filter($tag, $callback, $priority = 10) {
     global $filters;
@@ -71,9 +95,30 @@ function get_option($option, $default = false) {
     return array_key_exists($option, $options) ? $options[$option] : $default;
 }
 
+function update_option($option, $value) {
+    global $options;
+    $options[$option] = $value;
+    return true;
+}
+
+function delete_option($option) {
+    global $options;
+    unset($options[$option]);
+    return true;
+}
+
 function set_test_option($option, $value) {
     global $options;
     $options[$option] = $value;
+}
+
+function admin_url($path = '') {
+    return $path;
+}
+
+function add_query_arg($key, $value, $url) {
+    $separator = strpos($url, '?') === false ? '?' : '&';
+    return $url . $separator . $key . '=' . $value;
 }
 
 function reset_admin_structures() {
@@ -171,6 +216,48 @@ if (!$fallback_accessible) {
     $tests_passed = false;
     $results['fallback_submenu'] = isset($submenu['wma-admin-menu']) ? $submenu['wma-admin-menu'] : null;
 }
+
+$_POST = [
+    'wma_admin_menu_action'        => 'reset',
+    'option_page'                  => 'wma_admin_menu',
+    'action'                       => 'update',
+    '_wp_http_referer'             => 'options-general.php?page=wma-admin-menu',
+    'wma_admin_hidden_menus'       => ['edit.php'],
+    'wma_admin_hidden_submenus'    => ['options-general.php|options-writing.php'],
+];
+
+$_REQUEST = $_POST;
+$_SERVER['REQUEST_METHOD'] = 'POST';
+
+set_test_option('wma_admin_hidden_menus', ['edit.php']);
+set_test_option('wma_admin_hidden_submenus', ['options-general.php|options-writing.php']);
+
+do_action('admin_init');
+
+$menus_after_reset    = get_option('wma_admin_hidden_menus', []);
+$submenus_after_reset = get_option('wma_admin_hidden_submenus', []);
+
+if (!empty($menus_after_reset) || !empty($submenus_after_reset)) {
+    $tests_passed = false;
+    $results['reset_options'] = [
+        'menus'    => $menus_after_reset,
+        'submenus' => $submenus_after_reset,
+    ];
+}
+
+if (!isset($_POST['wma_admin_hidden_menus']) || $_POST['wma_admin_hidden_menus'] !== []) {
+    $tests_passed = false;
+    $results['reset_post_data'] = isset($_POST['wma_admin_hidden_menus']) ? $_POST['wma_admin_hidden_menus'] : null;
+}
+
+if (!isset($_POST['_wp_http_referer']) || false === strpos($_POST['_wp_http_referer'], 'wma-reset=1')) {
+    $tests_passed = false;
+    $results['reset_referer'] = isset($_POST['_wp_http_referer']) ? $_POST['_wp_http_referer'] : null;
+}
+
+$_POST = [];
+$_REQUEST = [];
+unset($_SERVER['REQUEST_METHOD']);
 
 if ($tests_passed) {
     echo "All tests passed\n";


### PR DESCRIPTION
## Summary
- add reset and back controls to the settings page and surface reset notices
- update assets to confirm resets, refresh rename fields, and style the new actions
- extend plugin tests and helpers to confirm reset clears stored menus and submenus

## Testing
- php tests/plugin_test.php

------
https://chatgpt.com/codex/tasks/task_e_68d0ffc40a948330ba5aaf5dd878a512