### PR TITLE
Add sortable admin menu ordering controls

### DIFF
--- a/assets/admin-menu.css
+++ b/assets/admin-menu.css
@@ -14,145 +14,182 @@
     font-weight: 600;
     letter-spacing: 0.04em;
     text-transform: uppercase;
-    color: #6c7781;
+    color: #64748b;
 }
 
 .wma-admin-menu__text-input {
     width: 100%;
-    border: 1px solid #dcdcde;
-    border-radius: 6px;
-    padding: 0.45rem 0.6rem;
+    border: 1px solid #d0d7de;
+    border-radius: 8px;
+    padding: 0.4rem 0.55rem;
     font-size: 13px;
     line-height: 1.4;
-    color: #1d2327;
-    background: #ffffff;
+    color: #0f172a;
+    background-color: #ffffff;
     transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
 }
 
 .wma-admin-menu__text-input:focus {
-    border-color: #2271b1;
-    box-shadow: 0 0 0 1px #2271b1;
+    border-color: #2563eb;
+    box-shadow: 0 0 0 1px #2563eb;
+    background-color: #f8fafc;
     outline: none;
-    background: #f7fbff;
+}
+
+.wma-admin-menu__drag-handle {
+    width: 1.5rem;
+    height: 1.5rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 0.45rem;
+    color: #94a3b8;
+    background: #f1f5f9;
+    cursor: grab;
+    transition: color 0.2s ease, background-color 0.2s ease;
+}
+
+.wma-admin-menu__drag-handle::before {
+    content: '';
+    width: 0.75rem;
+    height: 0.9rem;
+    background-image: radial-gradient(currentColor 25%, transparent 26%);
+    background-size: 0.2rem 0.2rem;
+    background-position: 0 0, 0.2rem 0.1rem;
+    background-repeat: repeat-y;
+}
+
+.wma-admin-menu__drag-handle:active {
+    cursor: grabbing;
 }
 
 .wma-admin-menu__menu-group {
-    border: 1px solid #dcdcde;
-    border-radius: 14px;
-    padding: 1.25rem;
+    border: 1px solid #d0d7de;
+    border-radius: 12px;
+    padding: 1.1rem;
     background: #ffffff;
     display: grid;
-    gap: 0.85rem;
+    gap: 0.75rem;
     max-width: 60rem;
-    box-shadow: 0 1px 2px rgba(30, 35, 40, 0.08);
+    box-shadow: 0 1px 1px rgba(15, 23, 42, 0.04);
 }
 
 .wma-admin-menu__menu-row {
     display: grid;
-    grid-template-columns: minmax(0, 1.4fr) minmax(12rem, 1fr);
-    gap: 1.25rem;
+    grid-template-columns: auto minmax(0, 1.4fr) minmax(12rem, 1fr);
+    gap: 0.75rem;
     align-items: center;
-    padding: 0.85rem 1.05rem;
+    padding: 0.65rem 0.85rem;
+    border: 1px solid #e2e8f0;
     border-radius: 10px;
-    border: 1px solid #edf0f3;
     background: #f9fafb;
-    transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease, transform 0.2s ease;
 }
 
 .wma-admin-menu__menu-row:hover {
-    border-color: #c8d7eb;
-    box-shadow: 0 8px 20px -18px rgba(34, 113, 177, 0.8);
+    border-color: #bfdbfe;
+    box-shadow: 0 8px 18px -16px rgba(37, 99, 235, 0.75);
+    background: #f8fafc;
 }
 
 .wma-admin-menu__menu-row.has-custom-label {
-    border-color: #2271b1;
-    background: #f3f8ff;
-    box-shadow: 0 12px 28px -20px rgba(34, 113, 177, 0.85);
+    border-color: #2563eb;
+    background: #eef2ff;
+    box-shadow: 0 10px 22px -18px rgba(37, 99, 235, 0.8);
+}
+
+.wma-admin-menu__menu-row.is-hidden {
+    opacity: 0.75;
+    background: #f1f5f9;
+}
+
+.wma-admin-menu__menu-row.is-dragging {
+    opacity: 0.65;
+    box-shadow: 0 12px 28px -20px rgba(37, 99, 235, 0.6);
 }
 
 .wma-admin-menu__menu-primary {
     display: flex;
     align-items: center;
-    gap: 0.65rem;
+    gap: 0.6rem;
 }
 
 .wma-admin-menu__menu-primary input[type="checkbox"] {
     margin: 0;
-    accent-color: #2271b1;
     width: 16px;
     height: 16px;
-    flex-shrink: 0;
+    accent-color: #2563eb;
 }
 
 .wma-admin-menu__menu-name {
     font-size: 14px;
     font-weight: 600;
-    color: #1d2327;
+    color: #111827;
 }
 
 .wma-admin-menu__menu-rename {
     display: flex;
     flex-direction: column;
     gap: 0.35rem;
+    grid-column: 3;
 }
 
 .wma-admin-menu__submenu-group {
     display: grid;
-    gap: 1.4rem;
-    margin-top: 1.8rem;
+    gap: 1.25rem;
+    margin-top: 1.6rem;
 }
 
 .wma-admin-menu__submenu-row {
-    border: 1px solid #dcdcde;
-    border-radius: 16px;
+    border: 1px solid #d0d7de;
+    border-radius: 12px;
     background: #ffffff;
-    box-shadow: 0 1px 3px rgba(30, 35, 40, 0.12);
+    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
     transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
     overflow: hidden;
 }
 
 .wma-admin-menu__submenu-row.is-open {
-    border-color: #2271b1;
-    box-shadow: 0 22px 32px -24px rgba(34, 113, 177, 0.9);
+    border-color: #2563eb;
+    box-shadow: 0 16px 28px -22px rgba(37, 99, 235, 0.7);
 }
 
 .wma-admin-menu__submenu-header {
     display: grid;
     grid-template-columns: minmax(0, 1.4fr) minmax(14rem, 1fr);
-    gap: 1.2rem;
     align-items: center;
-    padding: 1.05rem 1.3rem;
-    background: linear-gradient(180deg, #f9fafb 0%, #f2f3f5 100%);
-    border-bottom: 1px solid #e6e9ed;
+    gap: 0.85rem;
+    padding: 0.8rem 1rem;
+    background: #f8fafc;
+    border-bottom: 1px solid #e2e8f0;
 }
 
 .wma-admin-menu__submenu-row.is-open .wma-admin-menu__submenu-header {
-    background: linear-gradient(180deg, #f4f9ff 0%, #eaf3ff 100%);
+    background: #eff6ff;
 }
 
 .wma-admin-menu__submenu-toggle {
-    width: 100%;
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: 0.85rem;
-    padding: 0;
-    background: transparent;
+    gap: 0.65rem;
     border: 0;
-    cursor: pointer;
+    background: transparent;
     font-size: 15px;
     font-weight: 600;
-    color: #1d2327;
+    color: #0f172a;
+    padding: 0;
+    cursor: pointer;
     text-align: left;
 }
 
-.wma-admin-menu__submenu-row.is-open .wma-admin-menu__submenu-toggle {
-    color: #0a4b78;
+.wma-admin-menu__submenu-toggle:focus-visible {
+    outline: 2px solid #60a5fa;
+    outline-offset: 3px;
 }
 
-.wma-admin-menu__submenu-toggle:focus-visible {
-    outline: 2px solid #72aee6;
-    outline-offset: 3px;
+.wma-admin-menu__submenu-row.is-open .wma-admin-menu__submenu-toggle {
+    color: #1d4ed8;
 }
 
 .wma-admin-menu__submenu-title {
@@ -161,18 +198,17 @@
 }
 
 .wma-admin-menu__submenu-icon {
-    position: relative;
     width: 1rem;
     height: 1rem;
-    flex-shrink: 0;
+    position: relative;
     color: currentColor;
 }
 
 .wma-admin-menu__submenu-icon::before {
     content: '';
     position: absolute;
-    width: 0.6rem;
-    height: 0.6rem;
+    width: 0.55rem;
+    height: 0.55rem;
     border-top: 2px solid currentColor;
     border-right: 2px solid currentColor;
     top: 50%;
@@ -192,10 +228,10 @@
 }
 
 .wma-admin-menu__submenu-items {
-    padding: 1.1rem 1.3rem 1.3rem;
+    padding: 0.9rem 1rem 1.05rem;
     display: grid;
-    gap: 0.75rem;
-    background: #f6f7f7;
+    gap: 0.65rem;
+    background: #f3f4f6;
 }
 
 .wma-admin-menu__submenu-items[aria-hidden="true"] {
@@ -204,45 +240,55 @@
 
 .wma-admin-menu__submenu-item {
     display: grid;
-    grid-template-columns: minmax(0, 1.4fr) minmax(12rem, 1fr);
-    gap: 1rem;
+    grid-template-columns: auto minmax(0, 1.2fr) minmax(11rem, 1fr);
+    gap: 0.7rem;
     align-items: center;
-    padding: 0.7rem 0.9rem;
+    padding: 0.6rem 0.75rem;
+    border: 1px solid #e2e8f0;
     border-radius: 10px;
-    border: 1px solid #e3e7ec;
     background: #ffffff;
-    transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease, transform 0.2s ease;
 }
 
 .wma-admin-menu__submenu-item:hover {
-    border-color: #c8d7eb;
-    box-shadow: 0 10px 24px -22px rgba(34, 113, 177, 0.8);
+    border-color: #bfdbfe;
+    box-shadow: 0 10px 24px -20px rgba(37, 99, 235, 0.65);
+    background: #f8fafc;
 }
 
 .wma-admin-menu__submenu-item.has-custom-label {
-    border-color: #2271b1;
-    background: #f3f8ff;
-    box-shadow: 0 16px 30px -22px rgba(34, 113, 177, 0.88);
+    border-color: #2563eb;
+    background: #eef2ff;
+    box-shadow: 0 12px 28px -22px rgba(37, 99, 235, 0.75);
+}
+
+.wma-admin-menu__submenu-item.is-hidden {
+    opacity: 0.78;
+    background: #f1f5f9;
+}
+
+.wma-admin-menu__submenu-item.is-dragging {
+    opacity: 0.65;
+    box-shadow: 0 14px 30px -24px rgba(37, 99, 235, 0.65);
 }
 
 .wma-admin-menu__submenu-item-primary {
     display: flex;
     align-items: center;
-    gap: 0.65rem;
+    gap: 0.55rem;
 }
 
 .wma-admin-menu__submenu-item-primary input[type="checkbox"] {
     margin: 0;
-    accent-color: #2271b1;
     width: 16px;
     height: 16px;
-    flex-shrink: 0;
+    accent-color: #2563eb;
 }
 
 .wma-admin-menu__submenu-name {
     font-size: 13px;
     font-weight: 500;
-    color: #2c3338;
+    color: #1f2937;
 }
 
 .wma-admin-menu__submenu-item-field {
@@ -251,22 +297,39 @@
     gap: 0.35rem;
 }
 
+.wma-admin-menu__order-input {
+    display: none;
+}
+
 @media (max-width: 960px) {
-    .wma-admin-menu__menu-row,
-    .wma-admin-menu__submenu-header,
-    .wma-admin-menu__submenu-item {
-        grid-template-columns: 1fr;
+    .wma-admin-menu__menu-row {
+        grid-template-columns: auto minmax(0, 1fr);
+        align-items: flex-start;
+    }
+
+    .wma-admin-menu__menu-rename {
+        grid-column: 2;
     }
 
     .wma-admin-menu__submenu-header {
-        gap: 0.75rem;
+        grid-template-columns: minmax(0, 1fr);
+        gap: 0.6rem;
     }
 
-    .wma-admin-menu__menu-group {
-        padding: 1rem;
+    .wma-admin-menu__submenu-parent-field {
+        width: 100%;
+    }
+
+    .wma-admin-menu__submenu-item {
+        grid-template-columns: auto minmax(0, 1fr);
+        align-items: flex-start;
+    }
+
+    .wma-admin-menu__submenu-item-field {
+        grid-column: 2;
     }
 
     .wma-admin-menu__submenu-items {
-        padding: 1rem 1rem 1.2rem;
+        padding: 0.85rem 0.85rem 1rem;
     }
 }

--- a/tests/plugin_test.php
+++ b/tests/plugin_test.php
@@ -10,6 +10,8 @@ $options = [
     'wma_admin_hidden_submenus' => [],
     'wma_admin_menu_labels'     => [],
     'wma_admin_submenu_labels'  => [],
+    'wma_admin_menu_order'      => [],
+    'wma_admin_submenu_order'   => [],
 ];
 $wp_settings_errors = [];
 $settings_errors_calls = [];
@@ -177,6 +179,8 @@ set_test_option('wma_admin_hidden_menus', []);
 set_test_option('wma_admin_hidden_submenus', []);
 set_test_option('wma_admin_menu_labels', []);
 set_test_option('wma_admin_submenu_labels', []);
+set_test_option('wma_admin_menu_order', []);
+set_test_option('wma_admin_submenu_order', []);
 
 do_action('admin_menu');
 
@@ -208,6 +212,8 @@ set_test_option('wma_admin_menu_labels', ['options-general.php' => 'Site Options
 set_test_option('wma_admin_submenu_labels', [
     'options-general.php' => ['options-reading.php' => 'Reading Setup'],
 ]);
+set_test_option('wma_admin_menu_order', []);
+set_test_option('wma_admin_submenu_order', []);
 
 do_action('admin_menu');
 
@@ -233,10 +239,45 @@ if (!isset($submenu['options-general.php']) || $submenu['options-general.php'] !
 }
 
 reset_admin_structures();
+set_test_option('wma_admin_hidden_menus', []);
+set_test_option('wma_admin_hidden_submenus', []);
+set_test_option('wma_admin_menu_labels', []);
+set_test_option('wma_admin_submenu_labels', []);
+set_test_option('wma_admin_menu_order', ['index.php', 'options-general.php']);
+set_test_option('wma_admin_submenu_order', [
+    'options-general.php' => ['options-general.php', 'options-reading.php'],
+]);
+
+do_action('admin_menu');
+
+$expected_menu_stored_order = [
+    ['Dashboard', 'read', 'index.php'],
+    ['Settings', 'manage_options', 'options-general.php'],
+];
+
+$expected_submenu_stored_order = [
+    ['General', 'manage_options', 'options-general.php'],
+    ['Reading', 'manage_options', 'options-reading.php'],
+    ['WMA Admin Menu', 'manage_options', 'wma-admin-menu'],
+];
+
+if ($menu !== $expected_menu_stored_order) {
+    $tests_passed = false;
+    $results['stored_menu_order'] = $menu;
+}
+
+if (!isset($submenu['options-general.php']) || $submenu['options-general.php'] !== $expected_submenu_stored_order) {
+    $tests_passed = false;
+    $results['stored_submenu_order'] = isset($submenu['options-general.php']) ? $submenu['options-general.php'] : null;
+}
+
+reset_admin_structures();
 set_test_option('wma_admin_hidden_menus', ['options-general.php']);
 set_test_option('wma_admin_hidden_submenus', []);
 set_test_option('wma_admin_menu_labels', ['options-general.php' => 'Site Options']);
 set_test_option('wma_admin_submenu_labels', []);
+set_test_option('wma_admin_menu_order', []);
+set_test_option('wma_admin_submenu_order', []);
 
 do_action('admin_menu');
 


### PR DESCRIPTION
## Summary
- add stored menu and submenu order options with sanitizers and use them when applying admin menu filters
- render sortable top-level and submenu checklists that persist order choices and refresh the admin UI styling/behavior
- expand automated coverage for saved ordering and bump the plugin version to 1.0.5

## Testing
- php tests/plugin_test.php

------
https://chatgpt.com/codex/tasks/task_e_68d2b391dbc483309f2579e71bcced87